### PR TITLE
#263 fix: handle path with slashes

### DIFF
--- a/src/buildUrl.ts
+++ b/src/buildUrl.ts
@@ -40,7 +40,7 @@ const buildUrl = (options: Options): IO<string> => () => {
       ),
       path =>
         pipe(
-          list(serverUrl, hmac, operation, encodeURIComponent(path)),
+          list(serverUrl, hmac, operation, path),
           join('/')
         )
     )

--- a/test/__snapshots__/thumbor.spec.ts.snap
+++ b/test/__snapshots__/thumbor.spec.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`Thumbor Generates urls 1`] = `"https://thumbor/unsafe/example.png"`;
 
+exports[`Thumbor Generates urls when path has slashes 1`] = `"https://thumbor/unsafe/long/path/with/slashes/example.png"`;
+
 exports[`Thumbor Handles background color. 1`] = `"https://thumbor/unsafe/filters:background_color(#ffffff)/example.png"`;
 
 exports[`Thumbor Properly flips images 1`] = `"https://thumbor/unsafe/-30x-30/example.png"`;

--- a/test/thumbor.spec.ts
+++ b/test/thumbor.spec.ts
@@ -10,6 +10,14 @@ describe('Thumbor', () => {
     expect(image.buildUrl()).toMatchSnapshot();
   });
 
+  it('Generates urls when path has slashes', () => {
+    const imageWithLongPath = Thumbor({
+      serverUrl: 'https://thumbor',
+      imagePath: 'long/path/with/slashes/example.png'
+    });
+    expect(imageWithLongPath.buildUrl()).toMatchSnapshot();
+  });
+
   it('Handles background color.', () => {
     expect(
       image.backgroundColor('#ffffff').buildUrl()


### PR DESCRIPTION
This is a fix for the issue #263 . Now it handle urls with slashes and generate it correctly.